### PR TITLE
chore: replace brew tap/install with p6df::core::homebrew::cmd::brew

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -21,8 +21,8 @@ p6df::modules::cloudsmith::deps() {
 ######################################################################
 p6df::modules::cloudsmith::external::brews() {
 
-  brew tap cloudsmith-io/cloudsmith-cli
-  brew install cloudsmith-cli
+  p6df::core::homebrew::cmd::brew tap cloudsmith-io/cloudsmith-cli
+  p6df::core::homebrew::cmd::brew install cloudsmith-cli
 
   p6_return_void
 }


### PR DESCRIPTION
## Summary

- Replace `brew tap`/`brew install` in `init.zsh:24-25` with `p6df::core::homebrew::cmd::brew` wrappers

## Test plan

- [ ] `p6df::modules::cloudsmith::external::brews` installs cloudsmith-cli correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)