### PR TITLE
feat(profile): add CLOUDSMITH_API_KEY to profile mod

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -40,5 +40,5 @@ p6df::modules::cloudsmith::external::brews() {
 ######################################################################
 p6df::modules::cloudsmith::profile::mod() {
 
-  p6_return_words 'cloudsmith' "$"
+  p6_return_words 'cloudsmith' '$CLOUDSMITH_API_KEY'
 }


### PR DESCRIPTION
## What
Add `$CLOUDSMITH_API_KEY` to the `p6df::modules::cloudsmith::profile::mod` return value.

## Why
The profile mod was returning only the module name with a bare `"$"` placeholder. This populates it with the actual Cloudsmith API key env var that should be exported/tracked.

## Test plan
- Reviewed diff; change is a one-line string replacement in `init.zsh`
- No functional logic changed, only the return value of the profile mod function

## Dependencies
None