### PR TITLE
fix(profile): simplify profile::mod return signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,7 @@ TODO: Add a short summary of this module.
 
 - `p6df::modules::cloudsmith::deps()`
 - `p6df::modules::cloudsmith::external::brews()`
-- `p6df::modules::cloudsmith::profile::off()`
-- `p6df::modules::cloudsmith::profile::on(profile, api_key, entitlement_key)`
-  - Args:
-    - profile -
-    - api_key -
-    - entitlement_key -
-- `str str = p6df::modules::cloudsmith::prompt::mod()`
+- `words cloudsmith = p6df::modules::cloudsmith::profile::mod()`
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -30,10 +30,10 @@ p6df::modules::cloudsmith::external::brews() {
 ######################################################################
 #<
 #
-# Function: words cloudsmith $CLOUDSMITH_API_KEY = p6df::modules::cloudsmith::profile::mod()
+# Function: words cloudsmith = p6df::modules::cloudsmith::profile::mod()
 #
 #  Returns:
-#	words - cloudsmith $CLOUDSMITH_API_KEY
+#	words - cloudsmith
 #
 #  Environment:	 CLOUDSMITH_API_KEY
 #>


### PR DESCRIPTION
**What:** Remove env var from `profile::mod` return signature, returning only the module name word.

**Why:** Aligns with the updated `p6_return_words` convention where env vars are documented via the Environment section rather than encoded in the return value.

**Test plan:** Manual shell reload verification; no functional behavior change.

**Dependencies:** none